### PR TITLE
VNDLY-40597: Replace force_text with force_str

### DIFF
--- a/redis_cache/__init__.py
+++ b/redis_cache/__init__.py
@@ -2,4 +2,4 @@ from redis_cache.backends.single import RedisCache
 from redis_cache.backends.multiple import ShardedRedisCache
 from redis_cache.backends.dummy import RedisDummyCache
 
-__version__ = "v2.1.1-vndly-0.0.1"
+__version__ = "v2.1.1-vndly-0.0.2"

--- a/redis_cache/serializers.py
+++ b/redis_cache/serializers.py
@@ -15,7 +15,7 @@ try:
 except ImportError:
     pass
 
-from django.utils.encoding import force_bytes, force_text
+from django.utils.encoding import force_bytes, force_str
 
 
 class BaseSerializer(object):
@@ -51,7 +51,7 @@ class JSONSerializer(BaseSerializer):
         return force_bytes(json.dumps(value))
 
     def deserialize(self, value):
-        return json.loads(force_text(value))
+        return json.loads(force_str(value))
 
 
 class MSGPackSerializer(BaseSerializer):

--- a/redis_cache/sharder.py
+++ b/redis_cache/sharder.py
@@ -1,6 +1,6 @@
 from bisect import insort, bisect
 import hashlib
-from django.utils.encoding import force_text
+from django.utils.encoding import force_str
 
 
 DIGITS = 8
@@ -17,8 +17,8 @@ class Node(object):
         self._node = node
         self._i = i
         key = "{0}:{1}".format(
-            force_text(i),
-            force_text(self._node),
+            force_str(i),
+            force_str(self._node),
         )
         self._position = get_slot(key)
 
@@ -52,5 +52,5 @@ class HashRing(object):
                 del self._nodes[n - i - 1]
 
     def get_node(self, key):
-        i = bisect(self._nodes, get_slot(force_text(key))) - 1
+        i = bisect(self._nodes, get_slot(force_str(key))) - 1
         return self._nodes[i]._node

--- a/redis_cache/utils.py
+++ b/redis_cache/utils.py
@@ -2,7 +2,6 @@ import importlib
 import warnings
 
 from django.core.exceptions import ImproperlyConfigured
-from django.utils.encoding import force_text
 from six import python_2_unicode_compatible, string_types
 from six.moves.urllib.parse import parse_qs, urlparse
 


### PR DESCRIPTION
Required for Django 4.2 upgrade since django.utils.encoding.force_text is removed in Django 4.